### PR TITLE
Support for Mac M1 (ARM64)

### DIFF
--- a/src/clhash/clhash.c
+++ b/src/clhash/clhash.c
@@ -2,7 +2,13 @@
 
 #include <assert.h>
 #include <string.h>
+#if defined(__i386__) || defined(__x86_64__)
 #include <x86intrin.h>
+#elif defined(__aarch64__)
+#include "sse2neon.h"
+#else
+#error "This header is only meant to be used on x86/x64 or ARM64 architectures"
+#endif
 
 #ifdef __WIN32
 #define posix_memalign(p, a, s) (((*(p)) = _aligned_malloc((s), (a))), *(p) ?0 :errno)


### PR DESCRIPTION
Requires (for timeout command):
> brew install coreutils